### PR TITLE
Speed heap manipulation with Cython compiled functions

### DIFF
--- a/_heapdict.pxd
+++ b/_heapdict.pxd
@@ -1,0 +1,10 @@
+cdef int _parent(int i)
+cdef int _left(int i)
+cdef int _right(int i)
+cdef void _min_heapify(list heap, int i)
+cdef void _swap(list heap, int i, int j)
+cdef void _decrease_key(list heap, int i)
+
+cpdef heap_reheapify(list heap, list wrapper)
+cpdef heap_popitem(list heap)
+cpdef heap_append_and_decrease(list heap, list wrapper)

--- a/_heapdict.py
+++ b/_heapdict.py
@@ -1,0 +1,59 @@
+
+def _parent(i):
+    return ((i - 1) >> 1)
+
+def _left(i):
+    return ((i << 1) + 1)
+
+def _right(i):
+    return ((i+1) << 1)
+
+def _min_heapify(heap, i):
+    l = _left(i)
+    r = _right(i)
+    n = len(heap)
+    if l < n and heap[l][0] < heap[i][0]:
+        low = l
+    else:
+        low = i
+    if r < n and heap[r][0] < heap[low][0]:
+        low = r
+
+    if low != i:
+        _swap(heap, i, low)
+        _min_heapify(heap, low)
+
+def _swap(heap, i, j):
+    heap[i], heap[j] = heap[j], heap[i]
+    heap[i][2] = i
+    heap[j][2] = j
+
+def _decrease_key(heap, i):
+    while i:
+        parent = _parent(i)
+        if heap[parent][0] < heap[i][0]:
+            break
+        _swap(heap, i, parent)
+        i = parent
+
+def heap_reheapify(heap, wrapper):
+    while wrapper[2]:
+        parentpos = _parent(wrapper[2])
+        parent = heap[parentpos]
+        _swap(heap, wrapper[2], parent[2])
+
+def heap_popitem(heap):
+    wrapper = heap[0]
+    if len(heap) == 1:
+        heap.pop()
+    else:
+        heap[0] = heap.pop(-1)
+        heap[0][2] = 0
+        _min_heapify(heap, 0)
+    return wrapper
+
+def heap_append_and_decrease(heap, wrapper):
+    heap.append(wrapper)
+    _decrease_key(heap, len(heap)-1)
+
+__all__ = ['heap_reheapify', 'heap_popitem', 'heap_append_and_decrease']

--- a/heapdict.py
+++ b/heapdict.py
@@ -1,104 +1,42 @@
 import collections
+from _heapdict import heap_append_and_decrease, heap_reheapify, heap_popitem
 
-def doc(s):
-    if hasattr(s, '__call__'):
-        s = s.__doc__
-    def f(g):
-        g.__doc__ = s
-        return g
-    return f
 
 class heapdict(collections.MutableMapping):
-    __marker = object()
 
-    @staticmethod
-    def _parent(i):
-        return ((i - 1) >> 1)
-
-    @staticmethod
-    def _left(i):
-        return ((i << 1) + 1)
-
-    @staticmethod
-    def _right(i):
-        return ((i+1) << 1)    
-    
     def __init__(self, *args, **kw):
         self.heap = []
         self.d = {}
         self.update(*args, **kw)
 
-    @doc(dict.clear)
     def clear(self):
         self.heap.clear()
         self.d.clear()
 
-    @doc(dict.__setitem__)
     def __setitem__(self, key, value):
         if key in self.d:
-            self.pop(key)
+            del self[key]
         wrapper = [value, key, len(self)]
         self.d[key] = wrapper
-        self.heap.append(wrapper)
-        self._decrease_key(len(self.heap)-1)
+        heap_append_and_decrease(self.heap, wrapper)
 
-    def _min_heapify(self, i):
-        l = self._left(i)
-        r = self._right(i)
-        n = len(self.heap)
-        if l < n and self.heap[l][0] < self.heap[i][0]:
-            low = l
-        else:
-            low = i
-        if r < n and self.heap[r][0] < self.heap[low][0]:
-            low = r
-
-        if low != i:
-            self._swap(i, low)
-            self._min_heapify(low)
-
-    def _decrease_key(self, i):
-        while i:
-            parent = self._parent(i)
-            if self.heap[parent][0] < self.heap[i][0]: break
-            self._swap(i, parent)
-            i = parent
-
-    def _swap(self, i, j):
-        self.heap[i], self.heap[j] = self.heap[j], self.heap[i]
-        self.heap[i][2] = i
-        self.heap[j][2] = j
-
-    @doc(dict.__delitem__)
     def __delitem__(self, key):
         wrapper = self.d[key]
-        while wrapper[2]:
-            parentpos = self._parent(wrapper[2])
-            parent = self.heap[parentpos]
-            self._swap(wrapper[2], parent[2])
+        heap_reheapify(self.heap, wrapper)
         self.popitem()
 
-    @doc(dict.__getitem__)
     def __getitem__(self, key):
         return self.d[key][0]
 
-    @doc(dict.__iter__)
     def __iter__(self):
         return iter(self.d)
 
     def popitem(self):
         """D.popitem() -> (k, v), remove and return the (key, value) pair with lowest\nvalue; but raise KeyError if D is empty."""
-        wrapper = self.heap[0]
-        if len(self.heap) == 1:
-            self.heap.pop()
-        else:
-            self.heap[0] = self.heap.pop(-1)
-            self.heap[0][2] = 0
-            self._min_heapify(0)
+        wrapper = heap_popitem(self.heap)
         del self.d[wrapper[1]]
-        return wrapper[1], wrapper[0]    
+        return wrapper[1], wrapper[0]
 
-    @doc(dict.__len__)
     def __len__(self):
         return len(self.d)
 
@@ -106,5 +44,5 @@ class heapdict(collections.MutableMapping):
         """D.peekitem() -> (k, v), return the (key, value) pair with lowest value;\n but raise KeyError if D is empty."""
         return (self.heap[0][1], self.heap[0][0])
 
-del doc
+
 __all__ = ['heapdict']

--- a/perftest.py
+++ b/perftest.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python
+import os
+import timeit
+from random import shuffle
+from pickle import dump
+
+SAMPLES = '/tmp/heapdict-perftest.samples'
+
+if not os.path.exists(SAMPLES):
+    cats = range(100000)
+    score = [float(i)/2.0 for i in range(len(cats))]
+    shuffle(score)
+    docs = list(zip(cats, score))
+    with open(SAMPLES, 'wb') as samples:
+        dump(docs, samples)
+
+setup_fmt = '''
+from pickle import load
+from %(package)s import heapdict
+
+heap = heapdict()
+docs = load(open('%(SAMPLES)s', 'rb'))
+'''
+
+stmt = '''
+for k, v in docs:
+    heap[k] = v
+
+try:
+    while True:
+        heap.popitem()
+except IndexError:
+    pass
+'''
+
+def _timeit(package_name):
+    setup = setup_fmt % dict(package=package_name, SAMPLES=SAMPLES)
+    t = timeit.Timer(stmt, setup)
+    return min(t.repeat(repeat=3, number=1))
+
+t_python = _timeit('heapdict')
+print 'python = %f' % t_python

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ if sys.version_info[0] <= 2:
 else:
     from distutils.core import setup, Extension
 
-setup(name='HeapDict',
+
+kwargs = dict(name='HeapDict',
       version='1.0.0',
       description='a heap with decrease-key and increase-key operations',
       author='Stutzbach Enterprises, LLC',
@@ -35,5 +36,16 @@ setup(name='HeapDict',
           ],
 
       long_description=open('README.rst').read(),
-            
       )
+
+try:
+    from Cython.Distutils import build_ext
+except ImportError:
+    pass
+else:
+    kwargs['cmdclass'] = {'build_ext': build_ext}
+    kwargs['ext_modules'] = [
+            Extension("_heapdict", ["_heapdict.py"]),
+            ]
+
+setup(**kwargs)

--- a/test_heap.py
+++ b/test_heap.py
@@ -11,12 +11,15 @@ except ImportError:
 
 N = 100
 
+def _parent(i):
+    return ((i - 1) >> 1)
+
 class TestHeap(unittest.TestCase):
     def check_invariants(self, h):
         for i in range(len(h)):
             self.assertEqual(h.heap[i][2], i)
             if i > 0:
-                self.assertTrue(h.heap[h._parent(i)][0] <= h.heap[i][0])
+                self.assertTrue(h.heap[_parent(i)][0] <= h.heap[i][0])
 
     def make_data(self):
         pairs = [(random.random(), random.random()) for i in range(N)]


### PR DESCRIPTION
Hi Daniel, 

please, take a look to this pull request that adds an optional cython compiled extension for slow heap manipulation functions used by heapdict.

it increased performance by 5 times (python 2.6.5 + Cython 0.13), you can test it yourself using perftest.py script included in the changeset.

thanks for your time and for sharing heapdict with us,
Daniel
