### PR TITLE
Make pop() function which matches the documented behavior.

### DIFF
--- a/heapdict.py
+++ b/heapdict.py
@@ -8,7 +8,7 @@ def doc(s):
         return g
     return f
 
-class heapdict(collections.MutableMapping):
+class heapdict(collections.abc.MutableMapping):
     __marker = object()
 
     @staticmethod
@@ -43,19 +43,22 @@ class heapdict(collections.MutableMapping):
         self._decrease_key(len(self.heap)-1)
 
     def _min_heapify(self, i):
-        l = self._left(i)
-        r = self._right(i)
-        n = len(self.heap)
-        if l < n and self.heap[l][0] < self.heap[i][0]:
-            low = l
-        else:
-            low = i
-        if r < n and self.heap[r][0] < self.heap[low][0]:
-            low = r
+        while True:
+            l = self._left(i)
+            r = self._right(i)
+            n = len(self.heap)
+            if l < n and self.heap[l][0] < self.heap[i][0]:
+                low = l
+            else:
+                low = i
+            if r < n and self.heap[r][0] < self.heap[low][0]:
+                low = r
 
-        if low != i:
+            if low == i:
+                break
+
             self._swap(i, low)
-            self._min_heapify(low)
+            i = low
 
     def _decrease_key(self, i):
         while i:

--- a/heapdict.py
+++ b/heapdict.py
@@ -1,14 +1,17 @@
 import collections
 
+
 def doc(s):
     if hasattr(s, '__call__'):
         s = s.__doc__
+
     def f(g):
         g.__doc__ = s
         return g
     return f
 
-class heapdict(collections.abc.MutableMapping):
+
+class heapdict(collections.MutableMapping):
     __marker = object()
 
     def _check_invariants(self):
@@ -63,7 +66,8 @@ class heapdict(collections.abc.MutableMapping):
         while i:
             # calculate the offset of the parent
             parent = (i - 1) >> 1
-            if self.heap[parent][0] < self.heap[i][0]: break
+            if self.heap[parent][0] < self.heap[i][0]:
+                break
             self._swap(i, parent)
             i = parent
 
@@ -114,7 +118,7 @@ d is returned if given, otherwise KeyError is raised"""
             self.heap[0][2] = 0
             self._min_heapify(0)
         del self.d[wrapper[1]]
-        return wrapper[1], wrapper[0]    
+        return wrapper[1], wrapper[0]
 
     @doc(dict.__len__)
     def __len__(self):
@@ -123,6 +127,7 @@ d is returned if given, otherwise KeyError is raised"""
     def peekitem(self):
         """D.peekitem() -> (k, v), return the (key, value) pair with lowest value;\n but raise KeyError if D is empty."""
         return (self.heap[0][1], self.heap[0][0])
+
 
 del doc
 __all__ = ['heapdict']

--- a/heapdict.py
+++ b/heapdict.py
@@ -15,14 +15,6 @@ class heapdict(collections.abc.MutableMapping):
     def _parent(i):
         return ((i - 1) >> 1)
 
-    @staticmethod
-    def _left(i):
-        return ((i << 1) + 1)
-
-    @staticmethod
-    def _right(i):
-        return ((i+1) << 1)    
-    
     def __init__(self, *args, **kw):
         self.heap = []
         self.d = {}
@@ -44,8 +36,10 @@ class heapdict(collections.abc.MutableMapping):
 
     def _min_heapify(self, i):
         while True:
-            l = self._left(i)
-            r = self._right(i)
+            # calculate the offset of the left child
+            l = (i << 1) + 1
+            # calculate the offset of the right child
+            r = (i + 1) << 1
             n = len(self.heap)
             if l < n and self.heap[l][0] < self.heap[i][0]:
                 low = l

--- a/heapdict.py
+++ b/heapdict.py
@@ -43,12 +43,12 @@ class heapdict(collections.MutableMapping):
         self._decrease_key(len(self.heap)-1)
 
     def _min_heapify(self, i):
+        n = len(self.heap)
         while True:
             # calculate the offset of the left child
             l = (i << 1) + 1
             # calculate the offset of the right child
             r = (i + 1) << 1
-            n = len(self.heap)
             if l < n and self.heap[l][0] < self.heap[i][0]:
                 low = l
             else:

--- a/heapdict.py
+++ b/heapdict.py
@@ -36,7 +36,7 @@ class heapdict(collections.MutableMapping):
     @doc(dict.__setitem__)
     def __setitem__(self, key, value):
         if key in self.d:
-            self.pop(key)
+            del self[key]
         wrapper = [value, key, len(self)]
         self.d[key] = wrapper
         self.heap.append(wrapper)
@@ -85,6 +85,13 @@ class heapdict(collections.MutableMapping):
     @doc(dict.__iter__)
     def __iter__(self):
         return iter(self.d)
+
+    def pop(self, *args):
+        """D.pop() -> v, remove the key with the lowest value and return the corresponding\nvalue.\nRaises IndexError if list is empty."""
+        if len(self.d) == 0:
+            raise IndexError("pop from empty heapdict")
+        (k, v) = self.popitem()
+        return k
 
     def popitem(self):
         """D.popitem() -> (k, v), remove and return the (key, value) pair with lowest\nvalue; but raise KeyError if D is empty."""

--- a/heapdict.py
+++ b/heapdict.py
@@ -114,7 +114,7 @@ d is returned if given, otherwise KeyError is raised"""
         if len(self.heap) == 1:
             self.heap.pop()
         else:
-            self.heap[0] = self.heap.pop(-1)
+            self.heap[0] = self.heap.pop()
             self.heap[0][2] = 0
             self._min_heapify(0)
         del self.d[wrapper[1]]

--- a/heapdict.py
+++ b/heapdict.py
@@ -11,9 +11,14 @@ def doc(s):
 class heapdict(collections.abc.MutableMapping):
     __marker = object()
 
-    @staticmethod
-    def _parent(i):
-        return ((i - 1) >> 1)
+    def _check_invariants(self):
+        # the 3rd entry of each heap entry is the position in the heap
+        for i, e in enumerate(self.heap):
+            assert(e[2] == i)
+        # the parent of each heap element must not be larger than the element
+        for i in range(1, len(self.heap)):
+            parent = (i - 1) >> 1
+            assert self.heap[parent][0] <= self.heap[i][0]
 
     def __init__(self, *args, **kw):
         self.heap = []
@@ -56,7 +61,8 @@ class heapdict(collections.abc.MutableMapping):
 
     def _decrease_key(self, i):
         while i:
-            parent = self._parent(i)
+            # calculate the offset of the parent
+            parent = (i - 1) >> 1
             if self.heap[parent][0] < self.heap[i][0]: break
             self._swap(i, parent)
             i = parent
@@ -70,7 +76,8 @@ class heapdict(collections.abc.MutableMapping):
     def __delitem__(self, key):
         wrapper = self.d[key]
         while wrapper[2]:
-            parentpos = self._parent(wrapper[2])
+            # calculate the offset of the parent
+            parentpos = (wrapper[2] - 1) >> 1
             parent = self.heap[parentpos]
             self._swap(wrapper[2], parent[2])
         self.popitem()

--- a/heapdict.py
+++ b/heapdict.py
@@ -44,16 +44,17 @@ class heapdict(collections.MutableMapping):
 
     def _min_heapify(self, i):
         n = len(self.heap)
+        h = self.heap
         while True:
             # calculate the offset of the left child
             l = (i << 1) + 1
             # calculate the offset of the right child
             r = (i + 1) << 1
-            if l < n and self.heap[l][0] < self.heap[i][0]:
+            if l < n and h[l][0] < h[i][0]:
                 low = l
             else:
                 low = i
-            if r < n and self.heap[r][0] < self.heap[low][0]:
+            if r < n and h[r][0] < h[low][0]:
                 low = r
 
             if low == i:
@@ -61,6 +62,7 @@ class heapdict(collections.MutableMapping):
 
             self._swap(i, low)
             i = low
+        self.heap = h
 
     def _decrease_key(self, i):
         while i:
@@ -78,6 +80,7 @@ class heapdict(collections.MutableMapping):
 
     @doc(dict.__delitem__)
     def __delitem__(self, key):
+        # XXX: could we speed this up to avoid always walking tree?
         wrapper = self.d[key]
         while wrapper[2]:
             # calculate the offset of the parent

--- a/heapdict.py
+++ b/heapdict.py
@@ -17,7 +17,7 @@ class heapdict(collections.MutableMapping):
     def _check_invariants(self):
         # the 3rd entry of each heap entry is the position in the heap
         for i, e in enumerate(self.heap):
-            assert(e[2] == i)
+            assert e[2] == i
         # the parent of each heap element must not be larger than the element
         for i in range(1, len(self.heap)):
             parent = (i - 1) >> 1
@@ -103,7 +103,7 @@ d is returned if given, otherwise KeyError is raised"""
         if len(args) == 0:
             if len(self.d) == 0:
                 raise IndexError("pop from empty heapdict")
-            (k, v) = self.popitem()
+            (k, _) = self.popitem()
         else:
             k = super(heapdict, self).pop(*args)
         return k

--- a/heapdict.py
+++ b/heapdict.py
@@ -87,10 +87,17 @@ class heapdict(collections.MutableMapping):
         return iter(self.d)
 
     def pop(self, *args):
-        """D.pop() -> v, remove the key with the lowest value and return the corresponding\nvalue.\nRaises IndexError if list is empty."""
-        if len(self.d) == 0:
-            raise IndexError("pop from empty heapdict")
-        (k, v) = self.popitem()
+        """D.pop([k,[,d]]) -> v, if no key is specified, remove the key with the lowest
+value and return the corresponding value, raising IndexError if list is empty.
+If a key is specified, then it is removed instead if present and the
+corresponding value is returned. If the key is specified and not present, then
+d is returned if given, otherwise KeyError is raised"""
+        if len(args) == 0:
+            if len(self.d) == 0:
+                raise IndexError("pop from empty heapdict")
+            (k, v) = self.popitem()
+        else:
+            k = super(heapdict, self).pop(*args)
         return k
 
     def popitem(self):

--- a/heapdict.py
+++ b/heapdict.py
@@ -74,9 +74,11 @@ class heapdict(collections.MutableMapping):
             i = parent
 
     def _swap(self, i, j):
-        self.heap[i], self.heap[j] = self.heap[j], self.heap[i]
-        self.heap[i][2] = i
-        self.heap[j][2] = j
+        h = self.heap
+        h[i], h[j] = h[j], h[i]
+        h[i][2] = i
+        h[j][2] = j
+        self.heap = h
 
     @doc(dict.__delitem__)
     def __delitem__(self, key):

--- a/test_heap.py
+++ b/test_heap.py
@@ -44,7 +44,30 @@ class TestHeap(unittest.TestCase):
             # verify that our items are increasing in priority value
             self.assertGreater(priority, last_priority)
             last_priority = priority
-        # make sure that we got everythign out of the heap
+        # make sure that we got everything out of the heap
+        self.assertEqual(len(h), 0)
+        # now verify that we raise KeyError if we try to remove something 
+        # by key that is not present
+        empty_heap = heapdict()
+        self.assertRaises(KeyError, empty_heap.pop, "missing")
+        # verify that we do *not* get a KeyError if we specify a default
+        empty_heap = heapdict()
+        self.assertEqual(empty_heap.pop("missing", 123), 123)
+        # confirm that we can get a value by key if it is present
+        h = heapdict()
+        h["foo"] = 10
+        self.assertEqual(len(h), 1)
+        self.assertEqual(h.pop("foo"), 10)
+        self.assertEqual(len(h), 0)
+        # verify that removing keys does the right thing to a heap
+        h = heapdict()
+        h["c"] = 30
+        h["a"] = 10
+        h["b"] = 20
+        self.assertEqual(len(h), 3)
+        self.assertEqual(h.pop("b"), 20)
+        self.assertEqual(h.pop(), "a")
+        self.assertEqual(h.pop(), "c")
         self.assertEqual(len(h), 0)
 
     def test_popitem(self):

--- a/test_heap.py
+++ b/test_heap.py
@@ -5,11 +5,14 @@ import random
 import unittest
 import sys
 try:
-    import test.support as test_support # Python 3
+    # Python 3
+    import test.support as test_support
 except ImportError:
-    import test.test_support as test_support # Python 2
+    # Python 2
+    import test.test_support as test_support
 
 N = 100
+
 
 class TestHeap(unittest.TestCase):
 
@@ -23,7 +26,7 @@ class TestHeap(unittest.TestCase):
 
         pairs.sort(key=lambda x: x[1], reverse=True)
         return h, pairs, d
-    
+
     def test_pop(self):
         # verify that we raise IndexError on empty heapdict
         empty_heap = heapdict()
@@ -41,7 +44,7 @@ class TestHeap(unittest.TestCase):
             last_priority = priority
         # make sure that we got everything out of the heap
         self.assertEqual(len(h), 0)
-        # now verify that we raise KeyError if we try to remove something 
+        # now verify that we raise KeyError if we try to remove something
         # by key that is not present
         empty_heap = heapdict()
         self.assertRaises(KeyError, empty_heap.pop, "missing")
@@ -118,7 +121,7 @@ class TestHeap(unittest.TestCase):
         k, v = pairs[N//2]
         h[k] = 0.5
         pairs[N//2] = (k, 0.5)
-        pairs.sort(key = lambda x: x[1], reverse=True)
+        pairs.sort(key=lambda x: x[1], reverse=True)
         while pairs:
             v = h.popitem()
             v2 = pairs.pop()
@@ -130,11 +133,8 @@ class TestHeap(unittest.TestCase):
         h.clear()
         self.assertEqual(len(h), 0)
 
-#==============================================================================
 
 def test_main(verbose=None):
-    from types import BuiltinFunctionType
-
     test_classes = [TestHeap]
     test_support.run_unittest(*test_classes)
 
@@ -142,11 +142,12 @@ def test_main(verbose=None):
     if verbose and hasattr(sys, "gettotalrefcount"):
         import gc
         counts = [None] * 5
-        for i in xrange(len(counts)):
+        for i in range(len(counts)):
             test_support.run_unittest(*test_classes)
             gc.collect()
             counts[i] = sys.gettotalrefcount()
         print(counts)
+
 
 if __name__ == "__main__":
     test_main(verbose=True)

--- a/test_heap.py
+++ b/test_heap.py
@@ -12,11 +12,6 @@ except ImportError:
 N = 100
 
 class TestHeap(unittest.TestCase):
-    def check_invariants(self, h):
-        for i in range(len(h)):
-            self.assertEqual(h.heap[i][2], i)
-            if i > 0:
-                self.assertTrue(h.heap[h._parent(i)][0] <= h.heap[i][0])
 
     def make_data(self):
         pairs = [(random.random(), random.random()) for i in range(N)]
@@ -85,7 +80,7 @@ class TestHeap(unittest.TestCase):
         for i in range(N):
             k, v = h.popitem()
             self.assertEqual(v, 0)
-            self.check_invariants(h)
+            h._check_invariants()
 
     def test_peek(self):
         h, pairs, d = self.make_data()

--- a/test_heap.py
+++ b/test_heap.py
@@ -29,11 +29,29 @@ class TestHeap(unittest.TestCase):
         pairs.sort(key=lambda x: x[1], reverse=True)
         return h, pairs, d
     
+    def test_pop(self):
+        # verify that we raise IndexError on empty heapdict
+        empty_heap = heapdict()
+        self.assertRaises(IndexError, empty_heap.pop)
+        # test adding a bunch of random values at random priorities
+        h, pairs, d = self.make_data()
+        last_priority = 0
+        while pairs:
+            v1 = h.pop()
+            (v2, priority) = pairs.pop()
+            # confirm that our heapdict is returning things in sorted order
+            self.assertEqual(v1, v2)
+            # verify that our items are increasing in priority value
+            self.assertGreater(priority, last_priority)
+            last_priority = priority
+        # make sure that we got everythign out of the heap
+        self.assertEqual(len(h), 0)
+
     def test_popitem(self):
         h, pairs, d = self.make_data()
         while pairs:
             v = h.popitem()
-            v2 = pairs.pop(-1)
+            v2 = pairs.pop()
             self.assertEqual(v, v2)
         self.assertEqual(len(h), 0)
 
@@ -51,7 +69,7 @@ class TestHeap(unittest.TestCase):
         while pairs:
             v = h.peekitem()[0]
             h.popitem()
-            v2 = pairs.pop(-1)
+            v2 = pairs.pop()
             self.assertEqual(v, v2[0])
         self.assertEqual(len(h), 0)
 
@@ -73,7 +91,7 @@ class TestHeap(unittest.TestCase):
         del h[k]
         while pairs:
             v = h.popitem()
-            v2 = pairs.pop(-1)
+            v2 = pairs.pop()
             self.assertEqual(v, v2)
         self.assertEqual(len(h), 0)
 
@@ -85,7 +103,7 @@ class TestHeap(unittest.TestCase):
         pairs.sort(key = lambda x: x[1], reverse=True)
         while pairs:
             v = h.popitem()
-            v2 = pairs.pop(-1)
+            v2 = pairs.pop()
             self.assertEqual(v, v2)
         self.assertEqual(len(h), 0)
 

--- a/test_heap.py
+++ b/test_heap.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python
 from __future__ import print_function
-from heapdict import heapdict
 import random
-import unittest
 import sys
+import unittest
+from heapdict import heapdict
 try:
     # Python 3
     import test.support as test_support
@@ -32,7 +32,7 @@ class TestHeap(unittest.TestCase):
         empty_heap = heapdict()
         self.assertRaises(IndexError, empty_heap.pop)
         # test adding a bunch of random values at random priorities
-        h, pairs, d = self.make_data()
+        h, pairs, _ = self.make_data()
         last_priority = 0
         while pairs:
             v1 = h.pop()
@@ -69,7 +69,7 @@ class TestHeap(unittest.TestCase):
         self.assertEqual(len(h), 0)
 
     def test_popitem(self):
-        h, pairs, d = self.make_data()
+        h, pairs, _ = self.make_data()
         while pairs:
             v = h.popitem()
             v2 = pairs.pop()
@@ -81,12 +81,12 @@ class TestHeap(unittest.TestCase):
         for i in range(N):
             h[i] = 0
         for i in range(N):
-            k, v = h.popitem()
+            _, v = h.popitem()
             self.assertEqual(v, 0)
             h._check_invariants()
 
     def test_peek(self):
-        h, pairs, d = self.make_data()
+        h, pairs, _ = self.make_data()
         while pairs:
             v = h.peekitem()[0]
             h.popitem()
@@ -95,19 +95,19 @@ class TestHeap(unittest.TestCase):
         self.assertEqual(len(h), 0)
 
     def test_iter(self):
-        h, pairs, d = self.make_data()
+        h, _, d = self.make_data()
         self.assertEqual(list(h), list(d))
 
     def test_keys(self):
-        h, pairs, d = self.make_data()
+        h, _, d = self.make_data()
         self.assertEqual(list(sorted(h.keys())), list(sorted(d.keys())))
 
     def test_values(self):
-        h, pairs, d = self.make_data()
+        h, _, d = self.make_data()
         self.assertEqual(list(sorted(h.values())), list(sorted(d.values())))
 
     def test_del(self):
-        h, pairs, d = self.make_data()
+        h, pairs, _ = self.make_data()
         k, v = pairs.pop(N//2)
         del h[k]
         while pairs:
@@ -117,7 +117,7 @@ class TestHeap(unittest.TestCase):
         self.assertEqual(len(h), 0)
 
     def test_change(self):
-        h, pairs, d = self.make_data()
+        h, pairs, _ = self.make_data()
         k, v = pairs[N//2]
         h[k] = 0.5
         pairs[N//2] = (k, 0.5)
@@ -129,7 +129,7 @@ class TestHeap(unittest.TestCase):
         self.assertEqual(len(h), 0)
 
     def test_clear(self):
-        h, pairs, d = self.make_data()
+        h, _, _ = self.make_data()
         h.clear()
         self.assertEqual(len(h), 0)
 


### PR DESCRIPTION
The documentation of the pop() function in the README.rst file does not work, since heapdict inherited the pop() method from the dict class, which requires a key argument:

D.pop(k[,d]) -> v, remove specified key and return the corresponding value.
If key is not found, d is returned if given, otherwise KeyError is raised

I went ahead and added a pop() method that takes no key. I considered making a method that optionally took a key and default return value, but I considered that confusing as then you would have different semantics depending on how the function was called:
1. Without arguments, pop() would use the priority to decide what to remove
2. With arguments, pop() would use the key to  decide what to remove

It is of course possible to implement such a function, but in addition to the confusion in semantics, it would be a lot longer. :)
